### PR TITLE
fix: do not use the size of the segment when calculating phdrs

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -313,7 +313,7 @@ impl TempData {
                     return unsafe {
                         core::slice::from_raw_parts(
                             (self.segments.base() + phdr_start - cur_range.start) as *const Phdr,
-                            (cur_range.end - cur_range.start) / size_of::<Phdr>(),
+                            self.ehdr.e_phnum(),
                         )
                     };
                 }


### PR DESCRIPTION
The `(cur_range.end - cur_range.start)` is the size of the entire segment, not just the program headers. This PR fixes the size of the `phdrs` when creating an `ElfDylib`.

Also off topic, but do you plan on adding gdb support for `dlopen-rs` with symbols and all. It seems like a lot of stuff is missing from the `LinkMap`. I am not a 100% sure how gdb does it's stuff, but from what I understand it needs to be populated for symbol resolution etc. I can lend a helping hand but my time is kinda limited :smile: .

Also keep up the good work with this one, its a nice project!