### PR TITLE
Use current process's HANDLE when performing MapViewOfFile3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ windows-sys = { version = "0.59", features = [
 	"Win32_System_IO",
 	"Win32_Storage",
 	"Win32_Storage_FileSystem",
+	"Win32_System_Threading",
 ] }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -18,6 +18,7 @@ use windows_sys::Win32::{
         CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_BEGIN, FILE_SHARE_READ, OPEN_EXISTING, ReadFile,
         SetFilePointerEx,
     },
+    System::Threading::GetCurrentProcess,
     System::Memory::{
         self as Memory, CreateFileMappingW, MEM_COMMIT, MEM_PRESERVE_PLACEHOLDER, MEM_RELEASE,
         MEM_REPLACE_PLACEHOLDER, MEM_RESERVE, MEM_RESERVE_PLACEHOLDER, MapViewOfFile3,
@@ -88,7 +89,7 @@ impl Mmap for MmapImpl {
             let ptr = unsafe {
                 MapViewOfFile3(
                     handle,
-                    null_mut(),
+                    GetCurrentProcess(),
                     desired_addr,
                     offset as u64,
                     len,


### PR DESCRIPTION
For Windows OS, I noticed your `mmap` implementation uses `MapViewOfFile3`:

https://github.com/weizhiao/rust-elfloader/blob/f29bbbbe1e0228f3f8ad852aefca5dddc6cdcc6f/src/os/windows.rs#L73-L100

Here is [`MapViewOfFile3` specification](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffile3)' according to Win32 manual.

```C
PVOID MapViewOfFile3(
  [in]                HANDLE                 FileMapping,
  [in]                HANDLE                 Process,
...
```
The 2nd parameter should be "A HANDLE to a process into which the section will be mapped." 

If I understand it correctly, we should use `GetCurrentProcess()`, which always returns a pseudo handle -1 ([here](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess)) to map virtual memory into the current process. Your current implementation uses `null_mut()` as the parameter. 

> Update: Both would be fine. We can either use `GetCurrentProcess()` or use `null_mut()`. I prefer the former one as it is clearer.

