### PR TITLE
Expose DT_SONAME metadata

### DIFF
--- a/src/elf/defs/types.rs
+++ b/src/elf/defs/types.rs
@@ -32,11 +32,16 @@ impl ElfDynamicTag {
     pub const RELA: Self = Self(DT_RELA);
     pub const RELASZ: Self = Self(DT_RELASZ);
     pub const RELAENT: Self = Self(DT_RELAENT);
+    pub const SYMENT: Self = Self(DT_SYMENT);
     pub const REL: Self = Self(DT_REL);
     pub const RELSZ: Self = Self(DT_RELSZ);
     pub const RELENT: Self = Self(DT_RELENT);
     pub const PLTREL: Self = Self(DT_PLTREL);
     pub const DEBUG: Self = Self(DT_DEBUG);
+    pub const SONAME: Self = Self(DT_SONAME);
+    pub const SYMBOLIC: Self = Self(DT_SYMBOLIC);
+    pub const TEXTREL: Self = Self(DT_TEXTREL);
+    pub const BIND_NOW: Self = Self(DT_BIND_NOW);
     pub const JMPREL: Self = Self(DT_JMPREL);
     pub const INIT: Self = Self(DT_INIT);
     pub const FINI: Self = Self(DT_FINI);
@@ -49,6 +54,9 @@ impl ElfDynamicTag {
     pub const FLAGS: Self = Self(DT_FLAGS);
     pub const FLAGS_1: Self = Self(DT_FLAGS_1);
     pub const STRSZ: Self = Self(DT_STRSZ);
+    pub const PREINIT_ARRAY: Self = Self(DT_PREINIT_ARRAY);
+    pub const PREINIT_ARRAYSZ: Self = Self(DT_PREINIT_ARRAYSZ);
+    pub const SYMTAB_SHNDX: Self = Self(DT_SYMTAB_SHNDX);
     pub const GNU_HASH: Self = Self(DT_GNU_HASH);
     pub const GNU_LIBLIST: Self = Self(DT_GNU_LIBLIST);
     pub const VERSYM: Self = Self(DT_VERSYM);
@@ -99,10 +107,18 @@ impl Display for ElfDynamicTag {
             DT_SYMTAB => f.write_str("DT_SYMTAB"),
             DT_RELA => f.write_str("DT_RELA"),
             DT_RELASZ => f.write_str("DT_RELASZ"),
+            DT_RELAENT => f.write_str("DT_RELAENT"),
+            DT_STRSZ => f.write_str("DT_STRSZ"),
+            DT_SYMENT => f.write_str("DT_SYMENT"),
+            DT_SONAME => f.write_str("DT_SONAME"),
             DT_REL => f.write_str("DT_REL"),
             DT_RELSZ => f.write_str("DT_RELSZ"),
+            DT_RELENT => f.write_str("DT_RELENT"),
             DT_PLTREL => f.write_str("DT_PLTREL"),
             elf::abi::DT_DEBUG => f.write_str("DT_DEBUG"),
+            DT_SYMBOLIC => f.write_str("DT_SYMBOLIC"),
+            DT_TEXTREL => f.write_str("DT_TEXTREL"),
+            DT_BIND_NOW => f.write_str("DT_BIND_NOW"),
             DT_JMPREL => f.write_str("DT_JMPREL"),
             DT_INIT => f.write_str("DT_INIT"),
             DT_FINI => f.write_str("DT_FINI"),
@@ -114,6 +130,9 @@ impl Display for ElfDynamicTag {
             DT_RUNPATH => f.write_str("DT_RUNPATH"),
             DT_FLAGS => f.write_str("DT_FLAGS"),
             DT_FLAGS_1 => f.write_str("DT_FLAGS_1"),
+            DT_PREINIT_ARRAY => f.write_str("DT_PREINIT_ARRAY"),
+            DT_PREINIT_ARRAYSZ => f.write_str("DT_PREINIT_ARRAYSZ"),
+            DT_SYMTAB_SHNDX => f.write_str("DT_SYMTAB_SHNDX"),
             DT_GNU_HASH => f.write_str("DT_GNU_HASH"),
             DT_GNU_LIBLIST => f.write_str("DT_GNU_LIBLIST"),
             DT_VERSYM => f.write_str("DT_VERSYM"),
@@ -125,6 +144,7 @@ impl Display for ElfDynamicTag {
             DT_RELCOUNT => f.write_str("DT_RELCOUNT"),
             DT_RELR => f.write_str("DT_RELR"),
             DT_RELRSZ => f.write_str("DT_RELRSZ"),
+            DT_RELRENT => f.write_str("DT_RELRENT"),
             raw => write!(f, "unknown ELF dynamic tag {raw}"),
         }
     }

--- a/src/elf/dynamic.rs
+++ b/src/elf/dynamic.rs
@@ -83,8 +83,10 @@ pub(crate) struct ParsedDynamic {
     pub(crate) verneed_num: Option<NonZeroUsize>,
     pub(crate) verdef_off: Option<NonZeroUsize>,
     pub(crate) verdef_num: Option<NonZeroUsize>,
+    pub(crate) soname_off: Option<NonZeroUsize>,
     pub(crate) rpath_off: Option<NonZeroUsize>,
     pub(crate) runpath_off: Option<NonZeroUsize>,
+    pub(crate) bind_now: bool,
     pub(crate) flags: usize,
     pub(crate) flags_1: usize,
     pub(crate) is_rela: Option<bool>,
@@ -105,6 +107,8 @@ impl ParsedDynamic {
             }
             ElfDynamicTag::HASH => self.elf_hash_off = Some(value),
             ElfDynamicTag::GNU_HASH => self.gnu_hash_off = Some(value),
+            ElfDynamicTag::BIND_NOW => self.bind_now = true,
+            ElfDynamicTag::SONAME => self.soname_off = NonZeroUsize::new(value),
             ElfDynamicTag::SYMTAB => self.symtab_off = value,
             ElfDynamicTag::STRTAB => self.strtab_off = value,
             ElfDynamicTag::PLTRELSZ => self.pltrel_size = NonZeroUsize::new(value),
@@ -303,7 +307,8 @@ where
             symtab: add_base(parsed.symtab_off)?,
             strtab: add_base(parsed.strtab_off)?,
             // Check if binding should be done immediately
-            bind_now: parsed.flags & DF_BIND_NOW as usize != 0
+            bind_now: parsed.bind_now
+                || parsed.flags & DF_BIND_NOW as usize != 0
                 || parsed.flags_1 & DF_1_NOW as usize != 0,
             static_tls: parsed.flags & DF_STATIC_TLS as usize != 0,
             got_plt: parsed
@@ -320,6 +325,7 @@ where
             fini_fn,
             fini_array_fn,
             rel_count: parsed.rel_count,
+            soname_off: parsed.soname_off,
             rpath_off: parsed.rpath_off,
             runpath_off: parsed.runpath_off,
             version_idx,
@@ -378,6 +384,8 @@ pub(crate) struct ElfDynamic<Arch: RelocationArch = NativeArch> {
     pub verneed: Option<(NonZeroUsize, NonZeroUsize)>,
     /// Version definition information.
     pub verdef: Option<(NonZeroUsize, NonZeroUsize)>,
+    /// Shared-object name.
+    pub soname_off: Option<NonZeroUsize>,
     /// Runtime library search path.
     pub rpath_off: Option<NonZeroUsize>,
     /// Runtime library search path (overrides RPATH).
@@ -403,7 +411,8 @@ impl<Arch: RelocationArch> Debug for ElfDynamic<Arch> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ElfDyn, ElfDynamicTag};
+    use super::{ElfDyn, ElfDynamicTag, parse_dynamic_entries};
+    use core::num::NonZeroUsize;
 
     #[test]
     fn owned_dyn_round_trips_and_mutates() {
@@ -415,5 +424,17 @@ mod tests {
         dyn_.set_value(0x5678);
         assert_eq!(dyn_.tag(), ElfDynamicTag::NULL);
         assert_eq!(dyn_.value(), 0x5678);
+    }
+
+    #[test]
+    fn parses_metadata_only_dynamic_tags() {
+        let parsed = parse_dynamic_entries([
+            (ElfDynamicTag::SONAME, 0x24),
+            (ElfDynamicTag::BIND_NOW, 0),
+            (ElfDynamicTag::NULL, 0),
+        ]);
+
+        assert_eq!(parsed.soname_off, NonZeroUsize::new(0x24));
+        assert!(parsed.bind_now);
     }
 }

--- a/src/image/core.rs
+++ b/src/image/core.rs
@@ -98,6 +98,12 @@ impl<D: 'static, Arch: RelocationArch> LoadedCore<D, Arch> {
         self.core.name()
     }
 
+    /// Returns the DT_SONAME value when this is a dynamic object.
+    #[inline]
+    pub fn soname(&self) -> Option<&str> {
+        self.core.soname()
+    }
+
     /// Returns the short name of the ELF object.
     #[inline]
     pub fn short_name(&self) -> &str {
@@ -587,6 +593,15 @@ impl<D, Arch: RelocationArch> ElfCore<D, Arch> {
         &self.inner.name
     }
 
+    /// Returns the DT_SONAME value when this core has dynamic metadata.
+    #[inline]
+    pub fn soname(&self) -> Option<&str> {
+        self.inner
+            .dynamic_info
+            .as_ref()
+            .and_then(|info| info.soname)
+    }
+
     /// Gets the short name of the ELF object
     #[inline]
     pub fn short_name(&self) -> &str {
@@ -713,15 +728,20 @@ impl<D, Arch: RelocationArch> ElfCore<D, Arch> {
 
         segments.set_base(base);
         let dynamic = ElfDynamic::<Arch>::new(dynamic_ptr, &segments)?;
+        let symtab = SymbolTable::from_dynamic(&dynamic);
+        let soname = dynamic
+            .soname_off
+            .map(|soname_off| symtab.strtab().get_str(soname_off.get()));
         Ok(Self {
             inner: Arc::new(CoreInner {
                 name,
                 is_init: AtomicBool::new(true),
-                symtab: SymbolTable::from_dynamic(&dynamic),
+                symtab,
                 dynamic_info: Some(Arc::new(DynamicInfo {
                     eh_frame_hdr,
                     dynamic_ptr: unsafe { NonNull::new_unchecked(dynamic_ptr.cast_mut()) },
                     phdrs: ElfPhdrs::Vec(phdrs),
+                    soname,
                     #[cfg(feature = "lazy-binding")]
                     lazy: super::LazyBindingInfo::new(dynamic.pltrel),
                 })),

--- a/src/image/dylib.rs
+++ b/src/image/dylib.rs
@@ -124,6 +124,12 @@ impl<D, Arch: RelocationArch> RawDylib<D, Arch> {
         self.inner.runpath()
     }
 
+    /// Returns the DT_SONAME value.
+    #[inline]
+    pub fn soname(&self) -> Option<&str> {
+        self.inner.soname()
+    }
+
     /// Returns the PT_INTERP value.
     #[inline]
     pub fn interp(&self) -> Option<&str> {

--- a/src/image/dynamic.rs
+++ b/src/image/dynamic.rs
@@ -41,6 +41,7 @@ pub(crate) struct DynamicInfo<Arch: RelocationArch = NativeArch> {
     pub(crate) eh_frame_hdr: Option<NonNull<u8>>,
     pub(crate) dynamic_ptr: NonNull<ElfDyn<Arch::Layout>>,
     pub(crate) phdrs: ElfPhdrs<Arch::Layout>,
+    pub(crate) soname: Option<&'static str>,
     #[cfg(feature = "lazy-binding")]
     pub(crate) lazy: LazyBindingInfo<Arch>,
 }
@@ -209,6 +210,15 @@ impl<D, Arch: RelocationArch> RawDynamic<D, Arch> {
         self.extra.runpath
     }
 
+    /// Gets the DT_SONAME value
+    ///
+    /// # Returns
+    /// An optional string slice containing the shared-object name
+    #[inline]
+    pub fn soname(&self) -> Option<&str> {
+        self.module.soname()
+    }
+
     /// Gets the PT_INTERP value
     ///
     /// # Returns
@@ -360,6 +370,9 @@ impl<D: 'static, Arch: RelocationArch> RawDynamic<D, Arch> {
         if !needed_libs.is_empty() {
             logging::debug!("[{}] Dependencies: {:?}", name, needed_libs);
         }
+        let soname = dynamic
+            .soname_off
+            .map(|soname_off| symtab.strtab().get_str(soname_off.get()));
 
         let (tls_mod_id, tls_tp_offset) = if let Some(info) = &tls_info {
             if static_tls {
@@ -410,6 +423,7 @@ impl<D: 'static, Arch: RelocationArch> RawDynamic<D, Arch> {
                         eh_frame_hdr,
                         dynamic_ptr,
                         phdrs,
+                        soname,
                         #[cfg(feature = "lazy-binding")]
                         lazy: LazyBindingInfo::new(dynamic.pltrel),
                     })),

--- a/src/image/scanned.rs
+++ b/src/image/scanned.rs
@@ -20,6 +20,7 @@ struct DynamicScanParts {
     dynamic: ScannedDynamicInfo,
     strtab: Box<[u8]>,
     needed_libs: Box<[usize]>,
+    soname: Option<usize>,
     rpath: Option<usize>,
     runpath: Option<usize>,
 }
@@ -58,16 +59,20 @@ impl DynamicScanParts {
             .map(|offset| offset.get())
             .collect::<Vec<_>>()
             .into_boxed_slice();
+        let soname = parsed.soname_off.map(|offset| offset.get());
         let rpath = parsed.rpath_off.map(|offset| offset.get());
         let runpath = parsed.runpath_off.map(|offset| offset.get());
 
         Ok(Self {
             dynamic: ScannedDynamicInfo::new(
-                parsed.flags & DF_BIND_NOW as usize != 0 || parsed.flags_1 & DF_1_NOW as usize != 0,
+                parsed.bind_now
+                    || parsed.flags & DF_BIND_NOW as usize != 0
+                    || parsed.flags_1 & DF_1_NOW as usize != 0,
                 parsed.flags & DF_STATIC_TLS as usize != 0,
             ),
             strtab: strtab.into_boxed_slice(),
             needed_libs,
+            soname,
             rpath,
             runpath,
         })
@@ -170,6 +175,7 @@ pub struct ScannedDynamic<Arch: RelocationArch = NativeArch> {
     _strtab_bytes: Box<[u8]>,
     strtab: ElfStringTable,
     section_table: Option<SectionTable<Arch::Layout>>,
+    soname: Option<usize>,
     rpath: Option<usize>,
     runpath: Option<usize>,
     needed_libs: Box<[usize]>,
@@ -411,6 +417,7 @@ impl<Arch: RelocationArch> fmt::Debug for ScannedDynamic<Arch> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ScannedDynamic")
             .field("name", &self.name)
+            .field("soname", &self.soname())
             .field("needed_libs", &self.needed_libs().collect::<Vec<_>>())
             .field(
                 "sections",
@@ -582,6 +589,7 @@ impl<Arch: RelocationArch> ScannedDynamic<Arch> {
             dynamic,
             strtab,
             needed_libs,
+            soname,
             rpath,
             runpath,
         } = DynamicScanParts::new(reader.as_mut(), &phdrs)?;
@@ -601,6 +609,7 @@ impl<Arch: RelocationArch> ScannedDynamic<Arch> {
             _strtab_bytes: strtab,
             strtab: strtab_view,
             section_table,
+            soname,
             rpath,
             runpath,
             needed_libs,
@@ -659,6 +668,12 @@ impl<Arch: RelocationArch> ScannedDynamic<Arch> {
     #[inline]
     pub fn runpath(&self) -> Option<&str> {
         self.runpath.map(|offset| self.strtab.get_str(offset))
+    }
+
+    /// Returns the DT_SONAME string when present.
+    #[inline]
+    pub fn soname(&self) -> Option<&str> {
+        self.soname.map(|offset| self.strtab.get_str(offset))
     }
 
     /// Returns one `DT_NEEDED` entry by index.

--- a/tests/borrowed_mapped.rs
+++ b/tests/borrowed_mapped.rs
@@ -1,8 +1,8 @@
 mod support;
 
 use elf_loader::{Loader, image::ScannedElf, input::ElfBinary};
-use gen_elf::{Arch, SymbolDesc};
-use support::{generated_dylib::return_42_stub, test_dylib::write_test_dylib};
+use gen_elf::{Arch, ElfWriterConfig, SymbolDesc};
+use support::{generated_dylib::return_42_stub, test_dylib::write_test_dylib_with_config};
 
 #[derive(Default)]
 struct ScanData {
@@ -12,7 +12,10 @@ struct ScanData {
 #[test]
 fn borrowed_dynamic_reuses_existing_mapping() {
     let arch = Arch::current();
-    let output = write_test_dylib(
+    let output = write_test_dylib_with_config(
+        ElfWriterConfig::default()
+            .with_bind_now(true)
+            .with_soname("libowner.so"),
         &[],
         &[SymbolDesc::global_func("answer", &return_42_stub(arch))],
     );
@@ -41,12 +44,17 @@ fn borrowed_dynamic_reuses_existing_mapping() {
     assert!(borrowed.contains_addr(owner.base()));
     assert_eq!(borrowed.dynamic_ptr(), Some(owner_dynamic));
     assert_eq!(borrowed.needed_libs(), owner.needed_libs());
+    assert_eq!(owner.soname(), Some("libowner.so"));
+    assert_eq!(borrowed.soname(), owner.soname());
 }
 
 #[test]
 fn scanned_dynamic_load_reuses_scanned_metadata() {
     let arch = Arch::current();
-    let output = write_test_dylib(
+    let output = write_test_dylib_with_config(
+        ElfWriterConfig::default()
+            .with_bind_now(true)
+            .with_soname("libscanned.so"),
         &[],
         &[SymbolDesc::global_func("answer", &return_42_stub(arch))],
     );
@@ -64,12 +72,14 @@ fn scanned_dynamic_load_reuses_scanned_metadata() {
     else {
         panic!("generated dylib should scan as dynamic");
     };
+    assert_eq!(scanned.soname(), Some("libscanned.so"));
 
     let raw = loader
         .load_scanned_dynamic(scanned)
         .expect("failed to load scanned dynamic image");
 
     assert_eq!(raw.name(), "scanned.so");
+    assert_eq!(raw.soname(), Some("libscanned.so"));
     assert_eq!(raw.user_data().value, 42);
     assert!(raw.dynamic_ptr().is_some());
 }

--- a/tools/gen-elf/src/dylib/dynamic.rs
+++ b/tools/gen-elf/src/dylib/dynamic.rs
@@ -28,6 +28,7 @@ impl DynamicMetadata {
         sections: &[Section],
         allocator: &mut SectionAllocator,
         bind_now: bool,
+        soname_offset: Option<u32>,
         needed_offsets: &[u32],
     ) -> Self {
         let dynamic_id = allocator.allocate(0);
@@ -37,6 +38,9 @@ impl DynamicMetadata {
             dynamic_id,
         };
         instance.init_from_sections(sections);
+        if let Some(offset) = soname_offset {
+            instance.insert_entry(DT_SONAME as i64, offset as u64);
+        }
         for offset in needed_offsets {
             instance.insert_entry(DT_NEEDED as i64, *offset as u64);
         }

--- a/tools/gen-elf/src/dylib/mod.rs
+++ b/tools/gen-elf/src/dylib/mod.rs
@@ -63,6 +63,8 @@ pub struct ElfWriterConfig {
     pub bind_now: bool,
     /// Whether to emit one retained relocation section for the data section.
     pub emit_retained_relocations: bool,
+    /// DT_SONAME entry to emit into the dynamic section.
+    pub soname: Option<String>,
     /// DT_NEEDED entries to emit into the dynamic section.
     pub needed: Vec<String>,
 }
@@ -75,6 +77,7 @@ impl Default for ElfWriterConfig {
             ifunc_resolver_val: None,
             bind_now: false,
             emit_retained_relocations: false,
+            soname: None,
             needed: Vec::new(),
         }
     }
@@ -108,6 +111,12 @@ impl ElfWriterConfig {
     /// Emit a minimal retained relocation section for the data section.
     pub fn with_emit_retained_relocations(mut self, emit: bool) -> Self {
         self.emit_retained_relocations = emit;
+        self
+    }
+
+    /// Set the DT_SONAME entry for the generated ELF.
+    pub fn with_soname(mut self, name: impl Into<String>) -> Self {
+        self.soname = Some(name.into());
         self
     }
 
@@ -233,6 +242,7 @@ impl DylibWriter {
             self.arch,
             symbols,
             &final_relocs,
+            self.config.soname.as_deref(),
             &self.config.needed,
             &mut allocator,
         );
@@ -293,6 +303,7 @@ impl DylibWriter {
             &sections,
             &mut allocator,
             self.config.bind_now,
+            symtab.soname_offset(),
             symtab.needed_offsets(),
         );
         dyn_meta.create_section(&mut sections);

--- a/tools/gen-elf/src/dylib/symtab.rs
+++ b/tools/gen-elf/src/dylib/symtab.rs
@@ -53,6 +53,7 @@ pub(crate) struct SymTabMetadata {
     helper_index: HashMap<usize, usize>, // plt_sym_idx -> helper_sym_idx
     tls_helper_index: HashMap<usize, usize>, // tls_sym_idx -> helper_sym_idx
     symbols: Vec<SymbolDesc>,
+    soname_offset: Option<u32>,
     needed_offsets: Vec<u32>,
     dynsym_id: SectionId,
     dynsym_size: u64,
@@ -82,6 +83,7 @@ impl SymTabMetadata {
         arch: Arch,
         symbols: &[SymbolDesc],
         relocs: &[RelocEntry],
+        soname: Option<&str>,
         needed_libs: &[String],
         allocator: &mut SectionAllocator,
     ) -> Self {
@@ -97,6 +99,7 @@ impl SymTabMetadata {
             helper_index: HashMap::new(),
             tls_helper_index: HashMap::new(),
             symbols: vec![],
+            soname_offset: None,
             needed_offsets: Vec::new(),
             dynsym_id,
             dynstr_id,
@@ -129,6 +132,7 @@ impl SymTabMetadata {
         symtab.add_symbols(symbols);
         symtab.add_plt_symbols(relocs);
         symtab.add_tls_symbols(relocs);
+        symtab.soname_offset = soname.map(|name| symtab.dynstr.add(name));
         symtab.needed_offsets = needed_libs
             .iter()
             .map(|name| symtab.dynstr.add(name))
@@ -156,6 +160,10 @@ impl SymTabMetadata {
 
     pub(crate) fn needed_offsets(&self) -> &[u32] {
         &self.needed_offsets
+    }
+
+    pub(crate) fn soname_offset(&self) -> Option<u32> {
+        self.soname_offset
     }
 
     fn add_symbols(&mut self, symbols: &[SymbolDesc]) {


### PR DESCRIPTION
## Summary

- parse `DT_SONAME` from dynamic-section entries and retain it as dynamic metadata
- expose `soname()` on raw, scanned, and loaded dynamic image types while preserving `name()` semantics
- teach the test ELF generator to emit `DT_SONAME` and cover mapped/scanned load paths

## Tests

- `cargo check`
- `cargo test --lib`
- `cargo test --test borrowed_mapped`
- `cargo check --no-default-features`
- `cargo check --all-features`

Closes #55